### PR TITLE
fix: specify crio binaries paths in crio.conf

### DIFF
--- a/templates/crio.conf.j2
+++ b/templates/crio.conf.j2
@@ -112,7 +112,7 @@ conmon_cgroup = "system.slice"
 # Environment variable list for the conmon process, used for passing necessary
 # environment variables to conmon or the runtime.
 conmon_env = [
-	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 ]
 
 # Additional environment variables to set for all the
@@ -152,15 +152,15 @@ separate_pull_cgroup = ""
 # only the capabilities defined in the containers json file by the user/kube
 # will be added.
 default_capabilities = [
-	"CHOWN",
-	"DAC_OVERRIDE",
-	"FSETID",
-	"FOWNER",
-	"SETGID",
-	"SETUID",
-	"SETPCAP",
-	"NET_BIND_SERVICE",
-	"KILL",
+  "CHOWN",
+  "DAC_OVERRIDE",
+  "FSETID",
+  "FOWNER",
+  "SETGID",
+  "SETUID",
+  "SETPCAP",
+  "NET_BIND_SERVICE",
+  "KILL",
 ]
 
 # List of default sysctls. If it is empty or commented out, only the sysctls
@@ -178,7 +178,7 @@ additional_devices = [
 # Path to OCI hooks directories for automatically executed hooks. If one of the
 # directories does not exist, then CRI-O will automatically skip them.
 hooks_dir = [
-	"/usr/share/containers/oci/hooks.d",
+  "/usr/share/containers/oci/hooks.d",
 ]
 
 # Path to the file specifying the defaults mounts for each container. The
@@ -260,7 +260,7 @@ drop_infra_ctr = false
 namespaces_dir = "/var/run"
 
 # pinns_path is the path to find the pinns binary, which is needed to manage namespace lifecycle
-pinns_path = ""
+pinns_path = "{{ bin_dir }}/pinns"
 
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
 # The name is matched against the runtimes map below. If this value is changed,
@@ -304,7 +304,7 @@ default_runtime = "runc"
 
 
 [crio.runtime.runtimes.runc]
-runtime_path = ""
+runtime_path = "{{ bin_dir }}/runc"
 runtime_type = "oci"
 runtime_root = "/run/runc"
 
@@ -314,7 +314,7 @@ runtime_root = "/run/runc"
 # crun is a fast and lightweight fully featured OCI runtime and C library for
 # running containers
 [crio.runtime.runtimes.crun]
-runtime_path = ""
+runtime_path = "{{ bin_dir }}/crun"
 runtime_type = "oci"
 runtime_root = "/run/crun"
 
@@ -403,7 +403,7 @@ network_dir = "/etc/cni/net.d/"
 
 # Paths to directories where CNI plugin binaries are located.
 plugin_dirs = [
-	"/opt/cni/bin/",
+  "/opt/cni/bin/",
 ]
 
 # A necessary configuration for Prometheus based metrics retrieval


### PR DESCRIPTION
Hi, I added 3 absolute paths for `runc` `crun` and `pinns` in `crio.conf`.

On Archlinux, after `crio.service` start, the unit was failing:

```
msg="Validating runtime config: runtime validation: \"crun\" not found in $PATH: exec: \"crun\": executable file not found in $PATH"
```
and
```
msg="Validating runtime config: pinns validation: exec: \"pinns\": executable file not found in $PATH"
```

And alternative could have been to change PATH variable in configuration file, but I like it better this way.

If tabulation to space modifications are problematic, feel free to tell me I'll just commit the 3 lines with the fix.

Signed-off-by: Youenn Piolet <piolet.y@gmail.com>