### PR TITLE
ci: switch version management to workflow file

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible~=${{ secrets.ANSIBLE_VERSION }} yamllint ansible-lint
+          pip3 install ansible~=2.10 yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -59,7 +59,8 @@
   with_items: "{{ crio_binaries.files }}"
   notify: restart crio
 
-- meta: flush_handlers
+- name: Crio | Restart crio serving if necessary
+  meta: flush_handlers
 
 - name: Crio | Enable Crio unit
   systemd:


### PR DESCRIPTION
Defining variables inside repository secrets causes them to not be available during action run caused by external PR

Fix `ansible-lint` issue with unnamed flush_handlers meta task.