### PR TITLE
ci: use latest ansible version + schedule

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -2,6 +2,8 @@
 name: 'symplegma-crio'
 
 'on':
+  schedule:
+    - cron: '0 7 * * 1'  # every monday at 7am
   push:
     branches:
       - main
@@ -24,7 +26,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible~=2.10 yamllint ansible-lint
+          pip3 install ansible yamllint ansible-lint
 
       - name: Lint code.
         run: |


### PR DESCRIPTION
Run the symplegma-crio workflow every week
Use latest ansible version for linting

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>