### PR TITLE
fix(config): qualify paths with bin_dir variable in crio configuration

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -43,10 +43,14 @@
 
 - name: Crio | Drop crio runc config
   template:
-    src: 10-crun.conf.j2
-    dest: "{{ crio_config_dir }}/crio.conf.d/10-crun.conf"
+    src: "{{ item }}.j2"
+    dest: "{{ crio_config_dir }}/crio.conf.d/{{ item }}"
     mode: 'u+rw,g+r,o+r'
   notify: restart crio
+  loop:
+    - 10-crun.conf
+    - 10-conmon.conf
+    - 10-pinns.conf
 
 - name: Crio | Drop crio umount config
   template:

--- a/templates/10-conmon.conf.j2
+++ b/templates/10-conmon.conf.j2
@@ -1,0 +1,2 @@
+[crio.runtime]
+conmon = "{{ bin_dir }}/conmon"

--- a/templates/10-pinns.conf.j2
+++ b/templates/10-pinns.conf.j2
@@ -1,0 +1,2 @@
+[crio.runtime]
+pinns_path = "{{ bin_dir }}/pinns"


### PR DESCRIPTION
I had to deal with this issue for a while, sorry I didn't do a PR before!

On my distribution, adding {{ bin_dir }} in `/etc/profile.d/custom-path.sh` is not enough
```sh
PATH=/opt/bin:$PATH
```
The crio unit refuses to start because `pinns` and `crun` are nowhere to be found.

This MR is here to fully qualify all binary paths in crio configuration files.